### PR TITLE
Add failing test case for resolve on cancel

### DIFF
--- a/test.js
+++ b/test.js
@@ -135,10 +135,11 @@ test('PCancelable.CancelError', t => {
 });
 
 test.failing('resolves on cancel', async t => {
-	const p = new PCancelable((onCancel, resolve, reject) => {
+	const p = new PCancelable(onCancel => {
 		onCancel(() => {});
 	});
-	setTimeout(() => { p.cancel(); }, 100);
-	await t.throws(Promise.resolve(p));
+	setTimeout(() => {
+		p.cancel();
+	}, 100);
 	await t.throws(p);
 });

--- a/test.js
+++ b/test.js
@@ -133,3 +133,12 @@ test('PCancelable.fn()', async t => {
 test('PCancelable.CancelError', t => {
 	t.true(PCancelable.CancelError.prototype instanceof Error);
 });
+
+test.failing('resolves on cancel', async t => {
+	const p = new PCancelable((onCancel, resolve, reject) => {
+		onCancel(() => {});
+	});
+	setTimeout(() => { p.cancel(); }, 100);
+	await t.throws(Promise.resolve(p));
+	await t.throws(p);
+});


### PR DESCRIPTION
Not the issue I'm hunting for but seems problematic nonetheless.
Double checked it has nothing to do with `t.throws` too.
This fails, all the same, complaining that the promise never resolves.
```js
await p
	.then(() => { t.fail(); })
	.catch(() => { t.pass(); })
```
What is suspicious is that AVA knows the promise isn't going to resolve in <1s. Haven't dug into AVA to find out what this error means exactly.

Anyway, on to the test-case I'm looking for.