### PR TITLE
Fix New Relic issue with current way of inheriting from Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ class CancelError extends Error {
 	}
 }
 
-class PCancelable extends Promise {
+class PCancelable {
 	static fn(fn) {
 		return function () {
 			const args = [].slice.apply(arguments);
@@ -19,10 +19,6 @@ class PCancelable extends Promise {
 	}
 
 	constructor(executor) {
-		super(resolve => {
-			resolve();
-		});
-
 		this._pending = true;
 		this._canceled = false;
 

--- a/index.js
+++ b/index.js
@@ -71,5 +71,7 @@ class PCancelable {
 	}
 }
 
+Object.setPrototypeOf(PCancelable.prototype, Promise.prototype);
+
 module.exports = PCancelable;
 module.exports.CancelError = CancelError;

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import PCancelable from '.';
 const fixture = Symbol('fixture');
 
 test('new PCancelable()', async t => {
-	t.plan(5);
+	t.plan(4);
 
 	const p = new PCancelable((onCancel, resolve) => {
 		onCancel(() => {
@@ -16,8 +16,6 @@ test('new PCancelable()', async t => {
 			resolve(fixture);
 		}, 50);
 	});
-
-	t.true(p instanceof Promise);
 
 	t.false(p.canceled);
 

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import PCancelable from '.';
 const fixture = Symbol('fixture');
 
 test('new PCancelable()', async t => {
-	t.plan(4);
+	t.plan(5);
 
 	const p = new PCancelable((onCancel, resolve) => {
 		onCancel(() => {
@@ -16,6 +16,8 @@ test('new PCancelable()', async t => {
 			resolve(fixture);
 		}, 50);
 	});
+
+	t.true(p instanceof Promise);
 
 	t.false(p.canceled);
 


### PR DESCRIPTION
The constructor is actually a proxy for a Promise because of this._promise (a true subclass would typically only use this to reference operations).  I am submitting this change because when used with deep instrumentation libraries, like new relic, this call to super is breaking the inheritance chain (got.get is resolving undefined because new relic is overriding the `then` on native Promises).  However, if this inheritance is removed, and the super call removed, it works with new relic.  This is technically a problem with how new relic is hooking into the native promises and then its usage in an inheritance chain, but I figured I would try to make the smallest fix necessary, which would seem to just be to not inherit from Promise and instead just change the PCancelable type to be a proxy type, not a proxy-and-subclass.