### PR TITLE
Add support for `Promise.prototype.finally`

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,10 @@ class PCancelable {
 		return this._promise.catch(onRejected);
 	}
 
+	finally(onFinally) {
+		return this._promise.finally(onFinally);
+	}
+
 	cancel() {
 		if (!this._isPending || this._isCanceled) {
 			return;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	"devDependencies": {
 		"ava": "*",
 		"delay": "^2.0.0",
+		"promise.prototype.finally": "^3.1.0",
 		"xo": "*"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,9 @@
 import test from 'ava';
 import delay from 'delay';
+import promiseFinally from 'promise.prototype.finally';
 import PCancelable from '.';
+
+promiseFinally.shim();
 
 const fixture = Symbol('fixture');
 
@@ -170,4 +173,14 @@ test('cancel error includes a `isCanceled` property', async t => {
 
 	const err = await t.throws(p);
 	t.true(err.isCanceled);
+});
+
+test.cb('supports `finally`', t => {
+	const p = new PCancelable(resolve => {
+		setTimeout(resolve, 1);
+	});
+
+	p.finally(() => {
+		t.end();
+	});
 });


### PR DESCRIPTION
The proposal for `Promise.prototype.finally` [has reached stage 4](https://github.com/tc39/proposals/blob/master/finished-proposals.md) of the TC39 process and is already available via polyfills. It would be great for this library to support it.

Since the library instantiates a promise on its own, I wasn't able to inject a mocked promise with `finally` available on the prototype, but rather had to include a polyfill for the testsuite. I hope that's ok.