### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,168 @@
+/**
+ * Accepts a function that is called when the promise is canceled.
+ *
+ * You're not required to call this function. You can call this function multiple times to add multiple cancel handlers.
+ */
+export interface OnCancelFunction {
+	(cancelHandler: () => void): void;
+	shouldReject: boolean;
+}
+
+declare class PCancelable<ValueType> extends Promise<ValueType> {
+	/**
+	 * Convenience method to make your promise-returning or async function cancelable.
+	 *
+	 * @param fn A promise-returning function. The function you specify will have `onCancel` appended to its parameters.
+	 *
+	 * @example
+	 *
+	 * import PCancelable from 'p-cancelable';
+	 *
+	 * const fn = PCancelable.fn((input, onCancel) => {
+	 * 	const job = new Job();
+	 *
+	 * 	onCancel(() => {
+	 * 		job.cleanup();
+	 * 	});
+	 *
+	 * 	return job.start(); //=> Promise
+	 * });
+	 *
+	 * const cancelablePromise = fn('input'); //=> PCancelable
+	 *
+	 * // …
+	 *
+	 * cancelablePromise.cancel();
+	 */
+	static fn<ReturnType>(
+		userFn: (onCancel: OnCancelFunction) => PromiseLike<ReturnType>
+	): () => PCancelable<ReturnType>;
+	static fn<Agument1Type, ReturnType>(
+		userFn: (
+			argument1: Agument1Type,
+			onCancel: OnCancelFunction
+		) => PromiseLike<ReturnType>
+	): (argument1: Agument1Type) => PCancelable<ReturnType>;
+	static fn<Agument1Type, Agument2Type, ReturnType>(
+		userFn: (
+			argument1: Agument1Type,
+			argument2: Agument2Type,
+			onCancel: OnCancelFunction
+		) => PromiseLike<ReturnType>
+	): (
+		argument1: Agument1Type,
+		argument2: Agument2Type
+	) => PCancelable<ReturnType>;
+	static fn<Agument1Type, Agument2Type, Agument3Type, ReturnType>(
+		userFn: (
+			argument1: Agument1Type,
+			argument2: Agument2Type,
+			argument3: Agument3Type,
+			onCancel: OnCancelFunction
+		) => PromiseLike<ReturnType>
+	): (
+		argument1: Agument1Type,
+		argument2: Agument2Type,
+		argument3: Agument3Type
+	) => PCancelable<ReturnType>;
+	static fn<Agument1Type, Agument2Type, Agument3Type, Agument4Type, ReturnType>(
+		userFn: (
+			argument1: Agument1Type,
+			argument2: Agument2Type,
+			argument3: Agument3Type,
+			argument4: Agument4Type,
+			onCancel: OnCancelFunction
+		) => PromiseLike<ReturnType>
+	): (
+		argument1: Agument1Type,
+		argument2: Agument2Type,
+		argument3: Agument3Type,
+		argument4: Agument4Type
+	) => PCancelable<ReturnType>;
+	static fn<
+		Agument1Type,
+		Agument2Type,
+		Agument3Type,
+		Agument4Type,
+		Agument5Type,
+		ReturnType
+	>(
+		userFn: (
+			argument1: Agument1Type,
+			argument2: Agument2Type,
+			argument3: Agument3Type,
+			argument4: Agument4Type,
+			argument5: Agument5Type,
+			onCancel: OnCancelFunction
+		) => PromiseLike<ReturnType>
+	): (
+		argument1: Agument1Type,
+		argument2: Agument2Type,
+		argument3: Agument3Type,
+		argument4: Agument4Type,
+		argument5: Agument5Type
+	) => PCancelable<ReturnType>;
+	static fn<ReturnType>(
+		userFn: (...arguments: unknown[]) => PromiseLike<ReturnType>
+	): (...arguments: unknown[]) => PCancelable<ReturnType>;
+
+	/**
+	 * Create a promise that can be canceled.
+	 *
+	 * Can be constructed in the same was as a [`Promise` constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), but with an appended `onCancel` parameter in `executor`. `PCancelable` is a subclass of `Promise`.
+	 *
+	 * Cancelling will reject the promise with `CancelError`. To avoid that, set `onCancel.shouldReject` to `false`.
+	 *
+	 * @example
+	 *
+	 * import PCancelable from 'p-cancelable';
+	 *
+	 * const cancelablePromise = new PCancelable((resolve, reject, onCancel) => {
+	 * 	const job = new Job();
+	 *
+	 * 	onCancel.shouldReject = false;
+	 * 	onCancel(() => {
+	 * 		job.stop();
+	 * 	});
+	 *
+	 * 	job.on('finish', resolve);
+	 * });
+	 *
+	 * cancelablePromise.cancel(); // Doesn't throw an error
+	 */
+	constructor(
+		executor: (
+			resolve: (value?: ValueType | PromiseLike<ValueType>) => void,
+			reject: (reason?: unknown) => void,
+			onCancel: OnCancelFunction
+		) => void
+	);
+
+	/**
+	 * Whether the promise is canceled.
+	 */
+	readonly isCanceled: boolean;
+
+	/**
+	 * Cancel the promise and optionally provide a reason.
+	 *
+	 * The cancellation is synchronous. Calling it after the promise has settled or multiple times does nothing.
+	 *
+	 * @param reason - The cancellation reason to reject the promise with.
+	 */
+	cancel(reason?: string): void;
+}
+
+export default PCancelable;
+
+/**
+ * Rejection reason when `.cancel()` is called.
+ *
+ * It includes a `.isCanceled` property for convenience.
+ */
+export class CancelError extends Error {
+	readonly name: 'CancelError';
+	readonly isCanceled: true;
+
+	constructor(reason?: string);
+}

--- a/index.js
+++ b/index.js
@@ -98,4 +98,6 @@ class PCancelable {
 Object.setPrototypeOf(PCancelable.prototype, Promise.prototype);
 
 module.exports = PCancelable;
+module.exports.default = PCancelable;
+
 module.exports.CancelError = CancelError;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,106 @@
+import {expectType} from 'tsd-check';
+import PCancelable, {OnCancelFunction, CancelError} from '.';
+
+const cancelablePromise: PCancelable<number> = new PCancelable(
+	(resolve, reject, onCancel) => {
+		resolve(1);
+		resolve(Promise.resolve(1));
+
+		reject();
+		reject('foo');
+
+		expectType<OnCancelFunction>(onCancel);
+		onCancel(() => 'foo');
+		onCancel.shouldReject = false;
+	}
+);
+
+cancelablePromise.cancel();
+cancelablePromise.cancel('foo');
+expectType<boolean>(cancelablePromise.isCanceled);
+
+const function0 = PCancelable.fn(onCancel => {
+	expectType<OnCancelFunction>(onCancel);
+
+	return Promise.resolve(10);
+});
+expectType<() => PCancelable<number>>(function0);
+
+const function1 = PCancelable.fn(
+	(parameter1: string, onCancel: OnCancelFunction) => Promise.resolve(10)
+);
+expectType<(parameter1: string) => PCancelable<number>>(function1);
+
+const function2 = PCancelable.fn(
+	(parameter1: string, parameter2: boolean, onCancel: OnCancelFunction) =>
+		Promise.resolve(10)
+);
+expectType<(parameter1: string, parameter2: boolean) => PCancelable<number>>(
+	function2
+);
+
+const function3 = PCancelable.fn(
+	(
+		parameter1: string,
+		parameter2: boolean,
+		parameter3: number,
+		onCancel: OnCancelFunction
+	) => {
+		return Promise.resolve(10);
+	}
+);
+expectType<
+	(
+		parameter1: string,
+		parameter2: boolean,
+		parameter3: number
+	) => PCancelable<number>
+>(function3);
+
+const function4 = PCancelable.fn(
+	(
+		parameter1: string,
+		parameter2: boolean,
+		parameter3: number,
+		parameter4: symbol,
+		onCancel: OnCancelFunction
+	) => {
+		return Promise.resolve(10);
+	}
+);
+expectType<
+	(
+		parameter1: string,
+		parameter2: boolean,
+		parameter3: number,
+		parameter4: symbol
+	) => PCancelable<number>
+>(function4);
+
+const function5 = PCancelable.fn(
+	(
+		parameter1: string,
+		parameter2: boolean,
+		parameter3: number,
+		parameter4: symbol,
+		parameter5: null,
+		onCancel: OnCancelFunction
+	) => {
+		return Promise.resolve(10);
+	}
+);
+expectType<
+	(
+		parameter1: string,
+		parameter2: boolean,
+		parameter3: number,
+		parameter4: symbol,
+		parameter5: null
+	) => PCancelable<number>
+>(function5);
+
+const cancelError = new CancelError();
+new CancelError('foo');
+
+expectType<'CancelError'>(cancelError.name);
+expectType<true>(cancelError.isCanceled);

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd-check"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"promise",
@@ -39,9 +40,10 @@
 		"bluebird"
 	],
 	"devDependencies": {
-		"ava": "^0.25.0",
+		"ava": "^1.3.1",
 		"delay": "^4.1.0",
 		"promise.prototype.finally": "^3.1.0",
-		"xo": "^0.23.0"
+		"tsd-check": "^0.3.0",
+		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
I'm not really happy with the definition. I don't like that many overloads just to support functions with different arity for the `fn` method.

It would be much easier if `onCancel` would be passed in as first parameter instead of last:
```ts
static fn<ArgumentsType extends unknown[], ReturnType>(
	userFn: (onCancel: OnCancelFunction, ...arguments: ArgumentsType) => PromiseLike<ReturnType>
): (...arguments: ArgumentsType) => PCancelable<ReturnType>;
```


But I suppose it's not very ergonomic and would break all users' code...