### PR TITLE
Throw error if `onCancel` is called after promise settlement

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ class PCancelable {
 
 			const onCancel = handler => {
 				if (!this._isPending) {
-					throw new Error('onCancel handler was attached after the promise settled.');
+					throw new Error('The `onCancel` handler was attached after the promise settled.');
 				}
 
 				this._cancelHandlers.push(handler);

--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ class PCancelable {
 			};
 
 			const onCancel = handler => {
+				if (!this._isPending) {
+					throw Error('onCancel handler was attached after the promise settled.')
+				}
 				this._cancelHandlers.push(handler);
 			};
 

--- a/index.js
+++ b/index.js
@@ -42,8 +42,9 @@ class PCancelable {
 
 			const onCancel = handler => {
 				if (!this._isPending) {
-					throw Error('onCancel handler was attached after the promise settled.')
+					throw new Error('onCancel handler was attached after the promise settled.');
 				}
+
 				this._cancelHandlers.push(handler);
 			};
 


### PR DESCRIPTION
Related to #15, but it doesn't fix it; it just clarifies `p-cancelable`'s behavior.