### PR TITLE
Refactor TypeScript definition to CommonJS compatible export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,53 +1,65 @@
-/**
- * Accepts a function that is called when the promise is canceled.
- *
- * You're not required to call this function. You can call this function multiple times to add multiple cancel handlers.
- */
-export interface OnCancelFunction {
-	(cancelHandler: () => void): void;
-	shouldReject: boolean;
+declare class CancelErrorClass extends Error {
+	readonly name: 'CancelError';
+	readonly isCanceled: true;
+
+	constructor(reason?: string);
+}
+
+declare namespace PCancelable {
+	/**
+	Accepts a function that is called when the promise is canceled.
+
+	You're not required to call this function. You can call this function multiple times to add multiple cancel handlers.
+	*/
+	interface OnCancelFunction {
+		(cancelHandler: () => void): void;
+		shouldReject: boolean;
+	}
+
+	type CancelError = CancelErrorClass;
 }
 
 declare class PCancelable<ValueType> extends Promise<ValueType> {
 	/**
-	 * Convenience method to make your promise-returning or async function cancelable.
-	 *
-	 * @param fn - A promise-returning function. The function you specify will have `onCancel` appended to its parameters.
-	 *
-	 * @example
-	 *
-	 * import PCancelable from 'p-cancelable';
-	 *
-	 * const fn = PCancelable.fn((input, onCancel) => {
-	 * 	const job = new Job();
-	 *
-	 * 	onCancel(() => {
-	 * 		job.cleanup();
-	 * 	});
-	 *
-	 * 	return job.start(); //=> Promise
-	 * });
-	 *
-	 * const cancelablePromise = fn('input'); //=> PCancelable
-	 *
-	 * // …
-	 *
-	 * cancelablePromise.cancel();
-	 */
+	Convenience method to make your promise-returning or async function cancelable.
+
+	@param fn - A promise-returning function. The function you specify will have `onCancel` appended to its parameters.
+
+	@example
+	```
+	import PCancelable = require('p-cancelable');
+
+	const fn = PCancelable.fn((input, onCancel) => {
+		const job = new Job();
+
+		onCancel(() => {
+			job.cleanup();
+		});
+
+		return job.start(); //=> Promise
+	});
+
+	const cancelablePromise = fn('input'); //=> PCancelable
+
+	// …
+
+	cancelablePromise.cancel();
+	```
+	*/
 	static fn<ReturnType>(
-		userFn: (onCancel: OnCancelFunction) => PromiseLike<ReturnType>
+		userFn: (onCancel: PCancelable.OnCancelFunction) => PromiseLike<ReturnType>
 	): () => PCancelable<ReturnType>;
 	static fn<Agument1Type, ReturnType>(
 		userFn: (
 			argument1: Agument1Type,
-			onCancel: OnCancelFunction
+			onCancel: PCancelable.OnCancelFunction
 		) => PromiseLike<ReturnType>
 	): (argument1: Agument1Type) => PCancelable<ReturnType>;
 	static fn<Agument1Type, Agument2Type, ReturnType>(
 		userFn: (
 			argument1: Agument1Type,
 			argument2: Agument2Type,
-			onCancel: OnCancelFunction
+			onCancel: PCancelable.OnCancelFunction
 		) => PromiseLike<ReturnType>
 	): (
 		argument1: Agument1Type,
@@ -58,7 +70,7 @@ declare class PCancelable<ValueType> extends Promise<ValueType> {
 			argument1: Agument1Type,
 			argument2: Agument2Type,
 			argument3: Agument3Type,
-			onCancel: OnCancelFunction
+			onCancel: PCancelable.OnCancelFunction
 		) => PromiseLike<ReturnType>
 	): (
 		argument1: Agument1Type,
@@ -71,7 +83,7 @@ declare class PCancelable<ValueType> extends Promise<ValueType> {
 			argument2: Agument2Type,
 			argument3: Agument3Type,
 			argument4: Agument4Type,
-			onCancel: OnCancelFunction
+			onCancel: PCancelable.OnCancelFunction
 		) => PromiseLike<ReturnType>
 	): (
 		argument1: Agument1Type,
@@ -93,7 +105,7 @@ declare class PCancelable<ValueType> extends Promise<ValueType> {
 			argument3: Agument3Type,
 			argument4: Agument4Type,
 			argument5: Agument5Type,
-			onCancel: OnCancelFunction
+			onCancel: PCancelable.OnCancelFunction
 		) => PromiseLike<ReturnType>
 	): (
 		argument1: Agument1Type,
@@ -107,62 +119,58 @@ declare class PCancelable<ValueType> extends Promise<ValueType> {
 	): (...arguments: unknown[]) => PCancelable<ReturnType>;
 
 	/**
-	 * Create a promise that can be canceled.
-	 *
-	 * Can be constructed in the same was as a [`Promise` constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), but with an appended `onCancel` parameter in `executor`. `PCancelable` is a subclass of `Promise`.
-	 *
-	 * Cancelling will reject the promise with `CancelError`. To avoid that, set `onCancel.shouldReject` to `false`.
-	 *
-	 * @example
-	 *
-	 * import PCancelable from 'p-cancelable';
-	 *
-	 * const cancelablePromise = new PCancelable((resolve, reject, onCancel) => {
-	 * 	const job = new Job();
-	 *
-	 * 	onCancel.shouldReject = false;
-	 * 	onCancel(() => {
-	 * 		job.stop();
-	 * 	});
-	 *
-	 * 	job.on('finish', resolve);
-	 * });
-	 *
-	 * cancelablePromise.cancel(); // Doesn't throw an error
-	 */
+	Create a promise that can be canceled.
+
+	Can be constructed in the same was as a [`Promise` constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise), but with an appended `onCancel` parameter in `executor`. `PCancelable` is a subclass of `Promise`.
+
+	Cancelling will reject the promise with `CancelError`. To avoid that, set `onCancel.shouldReject` to `false`.
+
+	@example
+	```
+	import PCancelable = require('p-cancelable');
+
+	const cancelablePromise = new PCancelable((resolve, reject, onCancel) => {
+		const job = new Job();
+
+		onCancel.shouldReject = false;
+		onCancel(() => {
+			job.stop();
+		});
+
+		job.on('finish', resolve);
+	});
+
+	cancelablePromise.cancel(); // Doesn't throw an error
+	```
+	*/
 	constructor(
 		executor: (
 			resolve: (value?: ValueType | PromiseLike<ValueType>) => void,
 			reject: (reason?: unknown) => void,
-			onCancel: OnCancelFunction
+			onCancel: PCancelable.OnCancelFunction
 		) => void
 	);
 
 	/**
-	 * Whether the promise is canceled.
-	 */
+	Whether the promise is canceled.
+	*/
 	readonly isCanceled: boolean;
 
 	/**
-	 * Cancel the promise and optionally provide a reason.
-	 *
-	 * The cancellation is synchronous. Calling it after the promise has settled or multiple times does nothing.
-	 *
-	 * @param reason - The cancellation reason to reject the promise with.
-	 */
+	Cancel the promise and optionally provide a reason.
+
+	The cancellation is synchronous. Calling it after the promise has settled or multiple times does nothing.
+
+	@param reason - The cancellation reason to reject the promise with.
+	*/
 	cancel(reason?: string): void;
+
+	/**
+	Rejection reason when `.cancel()` is called.
+
+	It includes a `.isCanceled` property for convenience.
+	*/
+	static CancelError: typeof CancelErrorClass;
 }
 
-export default PCancelable;
-
-/**
- * Rejection reason when `.cancel()` is called.
- *
- * It includes a `.isCanceled` property for convenience.
- */
-export class CancelError extends Error {
-	readonly name: 'CancelError';
-	readonly isCanceled: true;
-
-	constructor(reason?: string);
-}
+export = PCancelable;

--- a/index.js
+++ b/index.js
@@ -98,6 +98,4 @@ class PCancelable {
 Object.setPrototypeOf(PCancelable.prototype, Promise.prototype);
 
 module.exports = PCancelable;
-module.exports.default = PCancelable;
-
 module.exports.CancelError = CancelError;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
-import {expectType} from 'tsd-check';
-import PCancelable, {OnCancelFunction, CancelError} from '.';
+import {expectType} from 'tsd';
+import PCancelable = require('.');
+import {OnCancelFunction, CancelError} from '.';
 
 const cancelablePromise: PCancelable<number> = new PCancelable(
 	(resolve, reject, onCancel) => {
@@ -102,5 +103,6 @@ expectType<
 const cancelError = new CancelError();
 new CancelError('foo');
 
+expectType<CancelError>(cancelError);
 expectType<'CancelError'>(cancelError.name);
 expectType<true>(cancelError.isCanceled);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd-check"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
@@ -40,10 +40,10 @@
 		"bluebird"
 	],
 	"devDependencies": {
-		"ava": "^1.3.1",
+		"ava": "^1.4.1",
 		"delay": "^4.1.0",
 		"promise.prototype.finally": "^3.1.0",
-		"tsd-check": "^0.3.0",
+		"tsd": "^0.7.1",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
**This is a breaking change.** I couldn't achieve compatibility with default export here. I suppose I could've tried harder but that would have meant to break up all class definitions into constructor and interface types. And even then, I'm not sure this would have worked.

It's already not simple to expose additional classes via `export = ...` syntax, just look at what I have to do to properly expose `CancelError`. It gets even harder when I try to mimic this darn `default` export.