### PR TITLE
Immediately call `onCancel` handlers when a promise is canceled

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,10 @@ class PCancelable {
 			this._reject = reject;
 
 			const onResolve = value => {
-				this._isPending = false;
-				resolve(value);
+				if (this._isCanceled !== true || onCancel.shouldReject === false) {
+					this._isPending = false;
+					resolve(value);
+				}
 			};
 
 			const onReject = error => {
@@ -46,7 +48,12 @@ class PCancelable {
 					throw new Error('The `onCancel` handler was attached after the promise settled.');
 				}
 
-				this._cancelHandlers.push(handler);
+				const fn = (...args) => {
+					this._isCanceled = true;
+					handler(...args);
+				};
+
+				this._cancelHandlers.push(fn);
 			};
 
 			Object.defineProperties(onCancel, {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class PCancelable {
 			this._reject = reject;
 
 			const onResolve = value => {
-				if (this._isCanceled !== true || onCancel.shouldReject === false) {
+				if (!this._isCanceled || !onCancel.shouldReject) {
 					this._isPending = false;
 					resolve(value);
 				}
@@ -48,12 +48,7 @@ class PCancelable {
 					throw new Error('The `onCancel` handler was attached after the promise settled.');
 				}
 
-				const fn = (...args) => {
-					this._isCanceled = true;
-					handler(...args);
-				};
-
-				this._cancelHandlers.push(fn);
+				this._cancelHandlers.push(handler);
 			};
 
 			Object.defineProperties(onCancel, {

--- a/test.js
+++ b/test.js
@@ -245,3 +245,23 @@ test('throws on cancel when `onCancel.shouldReject` is true', async t => {
 
 	await t.throwsAsync(cancelablePromise);
 });
+
+test('throws immediately as soon as .cancel() is called', async t => {
+	const cancelablePromise = new PCancelable((resolve, reject, onCancel) => {
+		const timeout = setTimeout(() => {
+			resolve(true);
+		}, 10);
+
+		onCancel.shouldReject = true;
+		onCancel(() => {
+			clearTimeout(timeout);
+			resolve(false);
+		});
+	});
+
+	cancelablePromise.cancel();
+
+	await t.throwsAsync(cancelablePromise, {
+		message: 'Promise was canceled'
+	});
+});


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/p-cancelable/issues/15