### PR TITLE
Simplify `cancel()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,8 @@ class PCancelable {
 			return;
 		}
 
+		this._isCanceled = true;
+
 		if (this._cancelHandlers.length > 0) {
 			try {
 				for (const handler of this._cancelHandlers) {
@@ -87,10 +89,10 @@ class PCancelable {
 				}
 			} catch (error) {
 				this._reject(error);
+				return;
 			}
 		}
 
-		this._isCanceled = true;
 		if (this._rejectOnCancel) {
 			this._reject(new CancelError(reason));
 		}


### PR DESCRIPTION
So when `handler()` throws, `new CancelError()` becomes moot. It can have a performance impact since the stack trace needs to be generated.