### PR TITLE
Fix TypeScript type for the cancel method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,7 +163,7 @@ declare class PCancelable<ValueType> extends Promise<ValueType> {
 
 	@param reason - The cancellation reason to reject the promise with.
 	*/
-	cancel(reason?: string): void;
+	cancel: (reason?: string) => void;
 
 	/**
 	Rejection reason when `.cancel()` is called.


### PR DESCRIPTION
When a project uses @types/bluebird-global there is a type clash, this PR makes a simple change to the typings file to allow p-cancelable to co-exist with @types/bluebird-global.

correct the following `tsc` error:

```
node_modules/p-cancelable/index.d.ts:166:2 - error TS2425: Class 'Promise<ValueType>' defines instance member property 'cancel', but extended class 'PCancelable<ValueType>' defines it as instance member function.
```